### PR TITLE
Changes to send same parameters to success callback when the toast hides automatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ If you like this plugin and want to say thanks please send a PR or donation. Bot
 1. [Description](#1-description)
 2. [Screenshots](#2-screenshots)
 3. [Installation](#3-installation)
-	3. [Automatically (CLI / Plugman)](#automatically-cli--plugman)
-	3. [Manually](#manually)
-	3. [PhoneGap Build](#phonegap-build)
+  3. [Automatically (CLI / Plugman)](#automatically-cli--plugman)
+  3. [Manually](#manually)
+  3. [PhoneGap Build](#phonegap-build)
 4. [Usage](#4-usage)
   4. [Styling](#styling)
 5. [Credits](#5-credits)
@@ -185,6 +185,24 @@ function hide() {
 }
 ```
 
+When the toast gets hidden, your success callback will be called (in case you have defined one) with the `event` property equals to `hide` (more details about the callback in the next section).
+```js
+
+  window.plugins.toast.showWithOptions({
+      message: 'My message',
+      // More config here...
+  },
+      //Success callback
+      function(args) {
+          console.log(args.event);
+          //This will print 'hide'
+      }, 
+      function(error) {
+          console.error('toast error: ', error);
+      }
+  );
+```
+
 ### Receiving a callback when a Toast is tapped
 On iOS and Android the success handler of your `show` function will be notified (again) when the toast was tapped.
 
@@ -203,16 +221,20 @@ called again. You can distinguish between those events of course:
     // implement the success callback
     function(result) {
       if (result && result.event) {
-        console.log("The toast was tapped");
-        console.log("Event: " + result.event); // will be defined, with a value of "touch" when it was tapped by the user
+        console.log("The toast was tapped or got hidden, see the value of result.event");
+        console.log("Event: " + result.event); // "touch" when the toast was touched by the user or "hide" when the toast geot hidden
         console.log("Message: " + result.message); // will be equal to the message you passed in
         console.log("data.foo: " + result.data.foo); // .. retrieve passed in data here
-      } else {
-        console.log("The toast has been shown");
+        
+        if (result.event === 'hide') {
+          console.log("The toast has been shown");
+        }
       }
     }
   );
 ```
+
+The success callback is useful when your toast is binded to a notification id in your backend and you have to mark it as `read` when the toast is done, or to update the notifications counter for iOS. The usage of this will be defined by your application logic. Use the `result.data` object to support your specific logic.
 
 ### Styling
 Since version 2.4.0 you can pass an optional `styling` object to the plugin.

--- a/src/android/nl/xservices/plugins/Toast.java
+++ b/src/android/nl/xservices/plugins/Toast.java
@@ -193,7 +193,10 @@ public class Toast extends CordovaPlugin {
           // trigger show every 2500 ms for as long as the requested duration
           _timer = new CountDownTimer(hideAfterMs, 2500) {
             public void onTick(long millisUntilFinished) {toast.show();}
-            public void onFinish() {toast.cancel();}
+            public void onFinish() {
+              returnTapEvent("hide", msg, data, callbackContext);
+              toast.cancel();
+            }
           }.start();
 
           mostRecentToast = toast;

--- a/src/android/nl/xservices/plugins/Toast.java
+++ b/src/android/nl/xservices/plugins/Toast.java
@@ -52,7 +52,18 @@ public class Toast extends CordovaPlugin {
         mostRecentToast.cancel();
         getViewGroup().setOnTouchListener(null);
       }
-      callbackContext.success();
+      final JSONObject hideOptions = args.getJSONObject(0);
+      final String hidemessage = hideOptions.getString("message");
+      final JSONObject hideData = hideOptions.has("data") ? hideOptions.getJSONObject("data") : null;
+      final JSONObject json = new JSONObject();
+      try {
+        json.put("event", "hide");
+        json.put("message", hidemessage);
+        json.put("data", hideData);
+      } catch (JSONException e) {
+        e.printStackTrace();
+      }
+      callbackContext.success(json);
       return true;
 
     } else if (ACTION_SHOW_EVENT.equals(action)) {

--- a/src/ios/Toast+UIView.m
+++ b/src/ios/Toast+UIView.m
@@ -185,6 +185,15 @@ static id styling;
 
 - (void)toastTimerDidFinish:(NSTimer *)timer {
     [self hideToast:(UIView *)timer.userInfo];
+    
+    // also send an event back to JS
+    NSMutableDictionary *dict = [[NSMutableDictionary alloc] initWithObjectsAndKeys:msg, @"message", @"hide", @"event", nil];
+    if (data != nil) {
+        [dict setObject:data forKey:@"data"];
+    }
+    
+    CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDictionary:dict];
+    [commandDelegate sendPluginResult:pluginResult callbackId:callbackId];
 }
 
 - (void)handleToastTapped:(UITapGestureRecognizer *)recognizer {


### PR DESCRIPTION
Sometimes a toast is bind to a notification handled by the backend of your app. Usually there is a "notification id" that you need to "clear" in the backend when you think the notification was delivered, no matter if the user has tapped the toast or not (this will be defined by your own app logic). Whit that said, there is a big chance users will need to know the value of "data" into the success callback when the toast hides from itself.

This PR just send the same data set to the success callback when the toast hides from itself but instead of notify the event as "touch" it uses the word "hide". The toast message and data remains the same.