### PR TITLE
Windows platform support.

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -72,13 +72,23 @@
     <source-file src="src/wp8/Toast.cs" />
   </platform>
 
-    <platform name="blackberry10">
-        <source-file src="src/blackberry10/index.js" target-dir="Toast"/>
-        <lib-file src="src/blackberry10/native/device/libToast.so" arch="device"/>
-        <lib-file src="src/blackberry10/native/simulator/libToast.so" arch="simulator"/>
-        <config-file target="www/config.xml" parent="/widget">
-            <feature name="Toast" value="Toast" />
-        </config-file>
-    </platform>
+  <platform name="blackberry10">
+    <source-file src="src/blackberry10/index.js" target-dir="Toast"/>
+      <lib-file src="src/blackberry10/native/device/libToast.so" arch="device"/>
+      <lib-file src="src/blackberry10/native/simulator/libToast.so" arch="simulator"/>
+      <config-file target="www/config.xml" parent="/widget">
+        <feature name="Toast" value="Toast" />
+      </config-file>
+  </platform>
+  
+  <!-- windows -->
+  <platform name="windows">
+    <js-module src="src/windows/toastProxy.js" name="ToastProxy">
+      <merges target="" />
+    </js-module>
+    <config-file target="config.xml" parent="/*">
+      <feature name="Toast" value="Toast" />
+    </config-file>
+  </platform>
   
 </plugin>

--- a/src/windows/toastProxy.js
+++ b/src/windows/toastProxy.js
@@ -1,0 +1,56 @@
+/**
+ * @author Piotr Smolarski <ph0ndragxdev@gmail.com>
+ */
+var toastProxy = {
+
+    lastDisplayedNotification: null,
+
+    show: function(successCallback, errorCallback, options) {
+        var notifications = Windows.UI.Notifications;
+
+        var template = notifications.ToastTemplateType.ToastText01;
+        var toastXml = notifications.ToastNotificationManager.getTemplateContent(template);
+
+        var toastTextElements = toastXml.getElementsByTagName("text");
+        toastTextElements[0].appendChild(toastXml.createTextNode(options[0].message));
+
+        var toastNode = toastXml.selectSingleNode("/toast");
+        toastNode.setAttribute("duration", options[0].duration);
+
+        var toast = new notifications.ToastNotification(toastXml);
+
+        toast.onactivated = function (event) {
+            toastProxy.lastDisplayedNotification = null;
+            successCallback({
+                event: "touch",
+                message: options[0].message,
+                data: options[0].data,
+            });
+        }
+
+        toast.ondismissed = function (event) {
+            toastProxy.lastDisplayedNotification = null;
+            successCallback({
+                event: "hide",
+                message: options[0].message,
+                data: options[0].data
+            });
+        }
+
+        toast.onfailed = function(err) {
+            toastProxy.lastDisplayedNotification = null;
+            errorCallback(err);
+        }
+
+        notifications.ToastNotificationManager.createToastNotifier().show(toast);
+    },
+
+    hide: function() {
+        if (this.lastDisplayedNotification !== null) {
+            notifications.ToastNotificationManager.createToastNotifier().hide(toast);
+            this.lastDisplayedNotification = null;
+        }
+    }
+}
+
+cordova.commandProxy.add("Toast", toastProxy);


### PR DESCRIPTION
I have added windows platform support using windows' native methods. It works on windows phone version >= 8.1 and on UWP. I wanted for it to work for windows phone from version 8.1, so plugin provides only basic support for Toasts, ignoring duration, styling and position.