### PR TITLE
Remove show toast method call from cancel timer to ensure that toast show is called only once.

### DIFF
--- a/src/android/nl/xservices/plugins/Toast.java
+++ b/src/android/nl/xservices/plugins/Toast.java
@@ -192,7 +192,7 @@ public class Toast extends CordovaPlugin {
           }
           // trigger show every 2500 ms for as long as the requested duration
           _timer = new CountDownTimer(hideAfterMs, 2500) {
-            public void onTick(long millisUntilFinished) {toast.show();}
+            public void onTick(long millisUntilFinished) { }
             public void onFinish() {
               returnTapEvent("hide", msg, data, callbackContext);
               toast.cancel();


### PR DESCRIPTION
I think there is a problem when calling the show method from the toast instance multiple times.